### PR TITLE
Added mapping for series.episodes if its no exists

### DIFF
--- a/vendor/github.com/tellytv/go.xtream-codes/xtream-codes.go
+++ b/vendor/github.com/tellytv/go.xtream-codes/xtream-codes.go
@@ -238,12 +238,12 @@ func (c *XtreamClient) GetSeriesInfo(seriesID string) (*Series, error) {
 		return nil, seriesErr
 	}
 
+	episodesMapper := &EpisodesMapper{}
+	seriesData = episodesMapper.Mapper(seriesData)
+
 	seriesInfo := &Series{}
 
 	jsonErr := json.Unmarshal(seriesData, &seriesInfo)
-	// if jsonErr != nil {
-	// 	utils.WriteResponseToFileWithOverwrite(nil, seriesData, false, url)
-	// }
 
 	return seriesInfo, jsonErr
 }


### PR DESCRIPTION
If the http request for “get_series_info” only returns a nested array instead of map[string][]SeriesEpisodes for series.episodes, the seasons can now be mapped.